### PR TITLE
Don't parse "ref:" lines as yaml

### DIFF
--- a/heuristics/newlines.go
+++ b/heuristics/newlines.go
@@ -97,6 +97,17 @@ func RecutNewLines(lines []string) []string {
 			continue
 		}
 
+		// If the line starts with ref: it's a reference and should be on its
+		// own line
+		if strings.HasPrefix(trimmedLine, "ref:") {
+			if len(currentLine) != 0 {
+				parsedLines = append(parsedLines, strings.Join(currentLine, " "))
+			}
+			parsedLines = append(parsedLines, lineWithoutLeadingSpaces)
+			currentLine = nil
+			continue
+		}
+
 		// If the previous line ends with certain characters
 		// (a colon, :, for example) we assume the new line was intentional and
 		// not just text wrapping

--- a/heuristics/sniffer.go
+++ b/heuristics/sniffer.go
@@ -101,10 +101,12 @@ func isLineTag(line string) bool {
 
 // isLineYamlRestrictive determine if the line is yaml(ish). It parses the line as
 // yaml and returns true only if the following criteria is met:
-// - It is a yaml map
-// - The map key has no spaces
-// - The map key starts with a lowercase letter
-// - If the map value contains spaces, the value must be quoted
+//   - It is a yaml map
+//   - The map key has no spaces
+//   - The map key starts with a lowercase letter
+//   - If the map value contains spaces, the value must be quoted
+//   - If the key is "ref", and the value is a URL then skip it (it's likely a
+//     comment referencing something)
 func isLineYamlRestrictive(line string) bool {
 	var node yaml.Node
 	if yaml.Unmarshal([]byte(line), &node) != nil {
@@ -137,6 +139,10 @@ func isNodeYamlRestrictive(node *yaml.Node) bool {
 		}
 
 		if strings.Contains(valueNode.Value, " ") && valueNode.Style != yaml.DoubleQuotedStyle && valueNode.Style != yaml.SingleQuotedStyle {
+			return false
+		}
+
+		if keyNode.Value == "ref" && strings.HasPrefix(valueNode.Value, "http") {
 			return false
 		}
 

--- a/heuristics/sniffer_test.go
+++ b/heuristics/sniffer_test.go
@@ -172,6 +172,28 @@ func TestContentSniffer_SniffContentType(t *testing.T) {
 			},
 		},
 		{
+			"ContentTypeText/Ref",
+			fields{},
+			args{
+				`ref: https://example.com`,
+			},
+			want{
+				ContentTypeText,
+				true,
+			},
+		},
+		{
+			"ContentTypeYaml/Ref",
+			fields{},
+			args{
+				`ref: "not a url"`,
+			},
+			want{
+				ContentTypeYaml,
+				true,
+			},
+		},
+		{
 			"ContentTypeTag/Basic",
 			fields{},
 			args{


### PR DESCRIPTION
We use "ref:" lines in our cert-manager docs to reference other documentation, this ensures they do not get converted to yaml