### PR TITLE
BUGFIX: WithProperty and WithIndex alter sibling paths

### DIFF
--- a/paths/path.go
+++ b/paths/path.go
@@ -108,11 +108,15 @@ func Parse(pathString string) (Path, error) {
 }
 
 func (p Path) WithProperty(part string) Path {
-	return append(p, mapPathComponent(part))
+	nePath := append(Path{}, p...)
+	nePath = append(nePath, mapPathComponent(part))
+	return nePath
 }
 
 func (p Path) WithIndex(idx int) Path {
-	return append(p, arrayPathComponent(idx))
+	nePath := append(Path{}, p...)
+	nePath = append(nePath, arrayPathComponent(idx))
+	return nePath
 }
 
 func (p Path) Property() pathComponent {

--- a/paths/path_test.go
+++ b/paths/path_test.go
@@ -73,3 +73,33 @@ func TestParsePath(t *testing.T) {
 		})
 	}
 }
+
+func TestWithProperty(t *testing.T) {
+	rootPath := Path{}.WithProperty("foo").WithProperty("bar").WithProperty("aaaa")
+
+	path1 := rootPath.WithProperty("baz1")
+	path2 := rootPath.WithProperty("baz2")
+
+	if path1.String() != "foo.bar.aaaa.baz1" {
+		t.Errorf("path1.String() = %v, expected %v", path1.String(), "foo.bar.aaaa.baz1")
+	}
+
+	if path2.String() != "foo.bar.aaaa.baz2" {
+		t.Errorf("path2.String() = %v, expected %v", path2.String(), "foo.bar.aaaa.baz2")
+	}
+}
+
+func TestWithIndex(t *testing.T) {
+	rootPath := Path{}.WithProperty("foo").WithProperty("bar").WithProperty("aaaa")
+
+	path1 := rootPath.WithIndex(0)
+	path2 := rootPath.WithIndex(1)
+
+	if path1.String() != "foo.bar.aaaa[0]" {
+		t.Errorf("path1.String() = %v, expected %v", path1.String(), "foo.bar.aaaa[0]")
+	}
+
+	if path2.String() != "foo.bar.aaaa[1]" {
+		t.Errorf("path2.String() = %v, expected %v", path2.String(), "foo.bar.aaaa[1]")
+	}
+}


### PR DESCRIPTION
Small bugfix that caused sibling paths to be altered by `WithProperty` and `WithIndex`.