### PR TITLE
Rewrite and fix linter diffing logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,9 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -103,8 +104,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=

--- a/linter/parsetemplates/templates_test.go
+++ b/linter/parsetemplates/templates_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cert-manager/helm-tool/linter/parsetemplates"
 	"github.com/cert-manager/helm-tool/linter/parsetemplates/funcs_serdes"
+	"github.com/cert-manager/helm-tool/linter/sets"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +40,7 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ .Values.foo }}",
 			},
 			expectedPaths: []string{
-				".foo",
+				"foo",
 			},
 		},
 		{
@@ -48,8 +49,8 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ .Values.bar }}",
 			},
 			expectedPaths: []string{
-				".foo",
-				".bar",
+				"foo",
+				"bar",
 			},
 		},
 		{
@@ -58,7 +59,7 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ .Values.foo }}",
 			},
 			expectedPaths: []string{
-				".foo",
+				"foo",
 			},
 		},
 		{
@@ -68,8 +69,8 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ .Values.bar }}",
 			},
 			expectedPaths: []string{
-				".foo",
-				".bar",
+				"foo",
+				"bar",
 			},
 		},
 		{
@@ -78,7 +79,7 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ .Values.bar }}",
 			},
 			expectedPaths: []string{
-				".bar",
+				"bar",
 			},
 		},
 		{
@@ -86,8 +87,7 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ range $key, $value := .Values.test }}{{ end }}",
 			},
 			expectedPaths: []string{
-				".test",
-				".test[*]",
+				"test[*]",
 			},
 		},
 		{
@@ -95,8 +95,7 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ $aa := .Values.test1.test2 }}",
 			},
 			expectedPaths: []string{
-				".test1",
-				".test1.test2",
+				"test1.test2",
 			},
 		},
 		{
@@ -104,9 +103,7 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ $aa := .Values.test1 }}{{ $bb := $aa.test2 }}{{ $bb.test3 }}",
 			},
 			expectedPaths: []string{
-				".test1",
-				".test1.test2",
-				".test1.test2.test3",
+				"test1.test2.test3",
 			},
 		},
 		{
@@ -114,8 +111,7 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ $value := .Values.test }}{{ $value.value }}",
 			},
 			expectedPaths: []string{
-				".test",
-				".test.value",
+				"test.value",
 			},
 		},
 		{
@@ -123,10 +119,8 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ $value := .Values.test1 }}{{ $value := .Values.test2 }}{{ $value.value }}",
 			},
 			expectedPaths: []string{
-				".test1",
-				".test1.value",
-				".test2",
-				".test2.value",
+				"test1.value",
+				"test2.value",
 			},
 		},
 		{
@@ -134,11 +128,8 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ range $key, $value := .Values.test }}{{ $key.key }}{{ $value.value.test1 }}{{ end }}",
 			},
 			expectedPaths: []string{
-				".test",
-				".test[*]",
-				".test[*].key",
-				".test[*].value",
-				".test[*].value.test1",
+				"test[*].key",
+				"test[*].value.test1",
 			},
 		},
 		{
@@ -146,8 +137,7 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ with .Values.test1 }}{{ .test2 }}{{ end }}",
 			},
 			expectedPaths: []string{
-				".test1",
-				".test1.test2",
+				"test1.test2",
 			},
 		},
 		{
@@ -155,7 +145,7 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ with .Values.test1 }}{{ . }}{{ end }}",
 			},
 			expectedPaths: []string{
-				".test1",
+				"test1",
 			},
 		},
 		{
@@ -163,8 +153,8 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ if .Values.test1 }}{{ . }}{{ .Values.test2 }}{{ end }}",
 			},
 			expectedPaths: []string{
-				".test1",
-				".test2",
+				"test1",
+				"test2",
 			},
 		},
 		{
@@ -174,10 +164,9 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ .Values.bar }}",
 			},
 			expectedPaths: []string{
-				".test1",
-				".test1.test2",
-				".foo",
-				".bar",
+				"test1.test2",
+				"foo",
+				"bar",
 			},
 		},
 		{
@@ -188,13 +177,9 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ template \"T1\" .Values.test1 }}{{ template \"T2\" .Values.test1 }}{{ template \"T3\" .Values.test1 }}",
 			},
 			expectedPaths: []string{
-				".test1",
-				".test1.test1",
-				".test1.test2",
-				".test1.test2.test1",
-				".test1.test3",
-				".test1.test3.test2",
-				".test1.test3.test2.test1",
+				"test1.test1",
+				"test1.test2.test1",
+				"test1.test3.test2.test1",
 			},
 		},
 		{
@@ -202,10 +187,8 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ $name := default .Values.test1 .Values.test2 }}{{ $name.test3 }}",
 			},
 			expectedPaths: []string{
-				".test1",
-				".test1.test3",
-				".test2",
-				".test2.test3",
+				"test1.test3",
+				"test2.test3",
 			},
 		},
 		{
@@ -213,10 +196,8 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ $name := (tuple .Values.test1 .Values.test2) }}{{ $name.test3 }}",
 			},
 			expectedPaths: []string{
-				".test1",
-				".test1.test3",
-				".test2",
-				".test2.test3",
+				"test1.test3",
+				"test2.test3",
 			},
 		},
 		{
@@ -224,10 +205,8 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ $name := (list .Values.test1 .Values.test2) }}{{ $name.test3 }}",
 			},
 			expectedPaths: []string{
-				".test1",
-				".test1.test3",
-				".test2",
-				".test2.test3",
+				"test1.test3",
+				"test2.test3",
 			},
 		},
 		{
@@ -236,10 +215,18 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 				"{{ template \"T1\" (tuple .Values.test1 .Values.test2) }}",
 			},
 			expectedPaths: []string{
-				".test1",
-				".test1.test3",
-				".test2",
-				".test2.test3",
+				"test1.test3",
+				"test2.test3",
+			},
+		},
+		{
+			templates: []string{
+				"{{ .Values.app.logLevela }}",
+				"{{ .Values.app.name }}",
+			},
+			expectedPaths: []string{
+				"app.logLevela",
+				"app.name",
 			},
 		},
 	}
@@ -249,7 +236,7 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 
 		tmpl.Funcs(funcs_serdes.FuncMap())
 
-		templates := parsetemplates.Set[*template.Template]{}
+		templates := sets.Set[*template.Template]{}
 		for idx, tem := range tc.templates {
 			tpl, err := tmpl.New(fmt.Sprintf("input-item-%d", idx)).Parse(tem)
 			if err != nil {
@@ -265,8 +252,10 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 		}
 
 		sort.Strings(tc.expectedPaths)
-		sort.Strings(paths)
 
-		require.EqualValues(t, tc.expectedPaths, paths)
+		pathList := paths.UnsortedList()
+		sort.Strings(pathList)
+
+		require.EqualValues(t, tc.expectedPaths, pathList)
 	}
 }

--- a/linter/sets/prefix.go
+++ b/linter/sets/prefix.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+import (
+	"maps"
+	"slices"
+	"strings"
+)
+
+// RemovePrefixes returns a new set with all items from
+// the input set that are not a prefix of another item in
+// the set or any of the additional sets. We consider a
+// string a prefix of another string if the other string
+// starts with the first string followed by a period or
+// an opening square bracket.
+func RemovePrefixes(items Set[string], sets ...Set[string]) Set[string] {
+	nonPrefixes := maps.Clone(items)
+
+	values := Union(append(sets, items)...).UnsortedList()
+	slices.Sort(values)
+	for i := 0; i < len(values); i++ {
+		// If the next value is an extension of the current value, skip
+		// the current value.
+		if i+1 < len(values) && (strings.HasPrefix(values[i+1], values[i]+".") || strings.HasPrefix(values[i+1], values[i]+"[")) {
+			nonPrefixes.Delete(values[i])
+		}
+	}
+
+	return nonPrefixes
+}
+
+// RemoveExtensions returns a new set with all items from
+// the input set that are not an extension of another item
+// in the set or any of the additional sets. We consider a
+// string a prefix of another string if the other string
+// starts with the first string followed by a period or
+// an opening square bracket.
+func RemoveExtensions(items Set[string], sets ...Set[string]) Set[string] {
+	nonExtensions := maps.Clone(items)
+
+	values := Union(append(sets, items)...).UnsortedList()
+	slices.Sort(values)
+	for i := 0; i < len(values); i++ {
+		// If the next value is an extension of the current value, skip
+		// the current value.
+		if i+1 < len(values) && (strings.HasPrefix(values[i+1], values[i]+".") || strings.HasPrefix(values[i+1], values[i]+"[")) {
+			nonExtensions.Delete(values[i+1])
+		}
+	}
+
+	return nonExtensions
+}

--- a/linter/sets/prefix_test.go
+++ b/linter/sets/prefix_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemovePrefixes(t *testing.T) {
+	tests := []struct {
+		input      Set[string]
+		additional Set[string]
+		expected   Set[string]
+	}{
+		{
+			input:      New("ab", "abd", "ab.d"),
+			additional: New("a", "ab"),
+			expected:   New("abd", "ab.d"),
+		},
+		{
+			input:      New("a", "a.b", "a.d"),
+			additional: New("a.b.c"),
+			expected:   New("a.d"),
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
+			result := RemovePrefixes(tt.input, tt.additional)
+			require.ElementsMatch(t, tt.expected.UnsortedList(), result.UnsortedList())
+		})
+	}
+}
+
+func TestRemoveExtensions(t *testing.T) {
+	tests := []struct {
+		input      Set[string]
+		additional Set[string]
+		expected   Set[string]
+	}{
+		{
+			input:      New("a.b.c"),
+			additional: New("a.b"),
+			expected:   New("a.b.c"),
+		},
+		{
+			input:      New("a.b.c", "a.b", "a.d"),
+			additional: New("a.b"),
+			expected:   New("a.b", "a.d"),
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
+			result := RemoveExtensions(tt.input)
+			require.ElementsMatch(t, tt.expected.UnsortedList(), result.UnsortedList())
+		})
+	}
+
+}


### PR DESCRIPTION
Rewrites the `DiffPaths` function and fix bug (only consider a string a prefix if it is delimited by a `.` or `[`).