### PR TITLE
Fix diff bug in RemoveExtensions caused by multiple prefixes; and fix bug in sorting

### DIFF
--- a/linter/diff_test.go
+++ b/linter/diff_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package linter
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cert-manager/helm-tool/linter/sets"
@@ -92,12 +93,20 @@ func TestDiffPaths(t *testing.T) {
 			wantMissingA: sets.New("app.logLevela", "app.name"),
 			wantMissingB: sets.New("app.test"),
 		},
+		{
+			a:            sets.New("app.test1", "app.test2"),
+			b:            sets.New("app"),
+			wantMissingA: sets.New[string](),
+			wantMissingB: sets.New[string](),
+		},
 	}
 
 	for _, tc := range testcases {
-		diffA, diffB := DiffPaths(tc.a, tc.b)
+		t.Run(fmt.Sprintf("%s-%s", tc.a, tc.b), func(t *testing.T) {
+			diffA, diffB := DiffPaths(tc.a, tc.b)
 
-		require.ElementsMatch(t, tc.wantMissingA.UnsortedList(), diffA.UnsortedList())
-		require.ElementsMatch(t, tc.wantMissingB.UnsortedList(), diffB.UnsortedList())
+			require.ElementsMatch(t, tc.wantMissingA.UnsortedList(), diffA.UnsortedList())
+			require.ElementsMatch(t, tc.wantMissingB.UnsortedList(), diffB.UnsortedList())
+		})
 	}
 }


### PR DESCRIPTION
This test case would fail previously for example: https://github.com/cert-manager/helm-tool/pull/24/files#diff-b4fab51df7d478873f36e650a90f7193c4c31ae51be4e2a418ea0f542c386d35R96-R101