### PR TITLE
Add support for missing `with (or ...)` variable detection.

### DIFF
--- a/linter/parsetemplates/templates_test.go
+++ b/linter/parsetemplates/templates_test.go
@@ -159,6 +159,14 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 		},
 		{
 			templates: []string{
+				"{{ if .Values.test1 }}{{ end }}",
+			},
+			expectedPaths: []string{
+				"test1",
+			},
+		},
+		{
+			templates: []string{
 				"{{define \"T1\" }}{{ .test2 }}{{end}} {{ .Values.foo }}",
 				"{{ template \"T1\" .Values.test1 }}",
 				"{{ .Values.bar }}",
@@ -227,6 +235,24 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 			expectedPaths: []string{
 				"app.logLevela",
 				"app.name",
+			},
+		},
+		{
+			templates: []string{
+				"{{- with (or .Values.test1 .Values.test2) }}{{- toYaml . | nindent 8 }}{{- end }}",
+			},
+			expectedPaths: []string{
+				"test1",
+				"test2",
+			},
+		},
+		{
+			templates: []string{
+				"{{- with (or .Values.test1 .Values.test2) }}aaa{{- end }}",
+			},
+			expectedPaths: []string{
+				"test1",
+				"test2",
 			},
 		},
 	}


### PR DESCRIPTION
The linter just walks the ast and tries to list all used variables.
We do have some shortcuts where we only find a subset of the used variables.
This PR adds some new test cases and more changes to walk more of the ast.