### PR TITLE
Add global value to JSON schema

### DIFF
--- a/schema/render.go
+++ b/schema/render.go
@@ -154,6 +154,12 @@ func Render(document *parser.Document) (string, error) {
 		definitions[prefixName(level.Path.String())] = newSchema
 	})
 
+	definitions["global"] = spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Description: "Global values shared across all (sub)charts",
+		},
+	}
+
 	type JsonSchema struct {
 		Schema string           `json:"$schema,omitempty"`
 		Ref    string           `json:"$ref,omitempty"`


### PR DESCRIPTION
fixes https://github.com/cert-manager/approver-policy/issues/389

Implements the workaround suggested by @ogarciacar in https://github.com/helm/helm/issues/10392#issuecomment-1513258871:
```json
{
   "$defs":{
      "helm-values":{
         "additionalProperties":false,
         "properties":{
            "global":{
               "$ref":"#/$defs/helm-values.global"
            }
         }
      },
      "helm-values.global":{
         "description":"Global values shared across all (sub)charts"
      }
   },
   "$ref":"#/$defs/helm-values",
   "$schema":"http://json-schema.org/draft-07/schema#"
}
```