### PR TITLE
Add global value to JSON schema (2nd try)

### DIFF
--- a/schema/render.go
+++ b/schema/render.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cert-manager/helm-tool/heuristics"
 	"github.com/cert-manager/helm-tool/parser"
 	"github.com/cert-manager/helm-tool/paths"
 	"gopkg.in/yaml.v3"
@@ -91,6 +92,23 @@ func buildTree(document *parser.Document) (treeLevel, error) {
 			return treeLevel{}, err
 		}
 	}
+
+	// Add a global section to the root, as this is a special case.
+	// TODO: also handle the case where there is a global section in the
+	// values.yaml file.
+	root.add(paths.Path{}.WithProperty("global"), parser.Property{
+		Type: parser.TypeUnknown,
+		Description: parser.Comment{
+			CommentBlock: heuristics.CommentBlock{
+				Segments: []heuristics.CommentBlockSegment{
+					{
+						Type:     heuristics.ContentTypeText,
+						Contents: []string{"Global values shared across all (sub)charts"},
+					},
+				},
+			},
+		},
+	})
 
 	return root, nil
 }

--- a/schema/render.go
+++ b/schema/render.go
@@ -154,12 +154,6 @@ func Render(document *parser.Document) (string, error) {
 		definitions[prefixName(level.Path.String())] = newSchema
 	})
 
-	definitions["global"] = spec.Schema{
-		SchemaProps: spec.SchemaProps{
-			Description: "Global values shared across all (sub)charts",
-		},
-	}
-
 	type JsonSchema struct {
 		Schema string           `json:"$schema,omitempty"`
 		Ref    string           `json:"$ref,omitempty"`


### PR DESCRIPTION
Reverts cert-manager/helm-tool#29 and applies the fix that I forgot to push.

fixes https://github.com/cert-manager/approver-policy/issues/389

Implements the workaround suggested by @ogarciacar in https://github.com/helm/helm/issues/10392#issuecomment-1513258871:
```json
{
   "$defs":{
      "helm-values":{
         "additionalProperties":false,
         "properties":{
            "global":{
               "$ref":"#/$defs/helm-values.global"
            }
         }
      },
      "helm-values.global":{
         "description":"Global values shared across all (sub)charts"
      }
   },
   "$ref":"#/$defs/helm-values",
   "$schema":"http://json-schema.org/draft-07/schema#"
}
```
