### PR TITLE
Add tag `+docs:hidden` to hide field from docs only

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Tags are used to alter how the documentation is generated. They are comments tha
 
 - `+docs:section=<name>` - Creates a new documentation section
 - `+docs:property` - Marks the field as a property that needs documentation
-- `+docs:ignore` - Ignore the field, not generating documentation
+- `+docs:ignore` - Ignore the field, not generating documentation, not used for linting or json schema generation
+- `+docs:hidden` - Hide the field from the documentation, but still use it for linting and json schema generation
 - `+docs:type=<type>` - Override the type information for the property
 - `+docs:default=<default>` - Override the default value for the property
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ var Render = cobra.Command{
 	Use:   "render",
 	Short: "render documentation to stdout",
 	Run: func(cmd *cobra.Command, args []string) {
-		document, err := parser.Load(valuesFile)
+		document, err := parser.Load(valuesFile, false)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Could not open %q: %s\n", valuesFile, err)
 			os.Exit(1)
@@ -66,7 +66,7 @@ var Inject = cobra.Command{
 	Use:   "inject",
 	Short: "generate documentation and inject into existing markdown file",
 	Run: func(cmd *cobra.Command, args []string) {
-		document, err := parser.Load(valuesFile)
+		document, err := parser.Load(valuesFile, false)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Could not open %q: %s\n", valuesFile, err)
 			os.Exit(1)
@@ -82,7 +82,7 @@ var Inject = cobra.Command{
 var Schema = cobra.Command{
 	Use: "schema",
 	Run: func(cmd *cobra.Command, args []string) {
-		document, err := parser.Load(valuesFile)
+		document, err := parser.Load(valuesFile, true)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Could not open %q: %s\n", valuesFile, err)
 			os.Exit(1)
@@ -101,7 +101,7 @@ var Schema = cobra.Command{
 var Lint = cobra.Command{
 	Use: "lint",
 	Run: func(cmd *cobra.Command, args []string) {
-		document, err := parser.Load(valuesFile)
+		document, err := parser.Load(valuesFile, true)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Could not open %q: %s\n", valuesFile, err)
 			os.Exit(1)

--- a/parser/document.go
+++ b/parser/document.go
@@ -29,6 +29,7 @@ import (
 const (
 	TagSection  = "docs:section"
 	TagIgnore   = "docs:ignore"
+	TagHidden   = "docs:hidden"
 	TagType     = "docs:type"
 	TagDefault  = "docs:default"
 	TagProperty = "docs:property"
@@ -90,7 +91,7 @@ type Node struct {
 	RawNode      *yaml.Node
 }
 
-func Load(filename string) (*Document, error) {
+func Load(filename string, includeHidden bool) (*Document, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -115,6 +116,11 @@ func Load(filename string) (*Document, error) {
 
 		// If we have a comment instructing us to skip this node, obey it
 		if comment.Tags.GetBool(TagIgnore) {
+			return true, nil
+		}
+
+		// If we have a comment instructing us to hide this node, obey it if we are not including hidden nodes
+		if comment.Tags.GetBool(TagHidden) && !includeHidden {
 			return true, nil
 		}
 


### PR DESCRIPTION
In case we have a Helm values option that shouldn't be included in the docs, but should be included in the json schema, we can now use the `+docs:hidden` tag.