### PR TITLE
Add missing release Make target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ env:
   VERSION: ${{ github.ref_name }}
 
 jobs:
-  build_images:
+  release_exe:
     runs-on: ubuntu-latest
 
     permissions:

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -13,3 +13,17 @@
 # limitations under the License.
 
 include make/test-unit.mk
+
+.PHONY: dryrun-release
+## Dry-run release process
+## @category [shared] Release
+dryrun-release: export RELEASE_DRYRUN := true
+dryrun-release: release
+
+.PHONY: release
+## Publish all release artifacts (image + helm chart)
+## @category [shared] Release
+release: | $(NEEDS_CRANE) $(bin_dir)/scratch
+	$(MAKE) exe-publish
+
+	@echo "Release complete!"


### PR DESCRIPTION
The binary build failed in the v0.5.0 release: https://github.com/cert-manager/helm-tool/actions/runs/9385799376/job/25844830188

This was caused by the missing release target.