### PR TITLE
Set versioning git in Renovate JSONata makefile-modules config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,7 @@
       "matchStrings": [
         'targets.*.{\
           "datasource": "git-refs",\
+          "versioning": "git",\
           "depName": folder_name,\
           "packageName": repo_url,\
           "currentValue": repo_ref,\


### PR DESCRIPTION
I see this spamming the Renovate logs. It will probably not help with the issue we have, but I don't think it would harm.
And when sharing the logs with the Renovate-people, I don't want additional "noise".

````
2025-09-09T02:58:59.6442628Z DEBUG: Dependency https://github.com/cert-manager/makefile-modules.git has unsupported/unversioned value main (versioning=semver-coerced) (repository=cert-manager/helm-tool)
2025-09-09T02:58:59.6472604Z DEBUG: Dependency https://github.com/cert-manager/makefile-modules.git has unsupported/unversioned value main (versioning=semver-coerced) (repository=cert-manager/helm-tool)
2025-09-09T02:58:59.6476118Z DEBUG: Dependency https://github.com/cert-manager/makefile-modules.git has unsupported/unversioned value main (versioning=semver-coerced) (repository=cert-manager/helm-tool)
2025-09-09T02:58:59.6498054Z DEBUG: Dependency https://github.com/cert-manager/makefile-modules.git has unsupported/unversioned value main (versioning=semver-coerced) (repository=cert-manager/helm-tool)
2025-09-09T02:58:59.6501487Z DEBUG: Dependency https://github.com/cert-manager/makefile-modules.git has unsupported/unversioned value main (versioning=semver-coerced) (repository=cert-manager/helm-tool)
2025-09-09T02:58:59.6521586Z DEBUG: Dependency https://github.com/cert-manager/makefile-modules.git has unsupported/unversioned value main (versioning=semver-coerced) (repository=cert-manager/helm-tool)
2025-09-09T02:58:59.6526424Z DEBUG: Dependency https://github.com/cert-manager/makefile-modules.git has unsupported/unversioned value main (versioning=semver-coerced) (repository=cert-manager/helm-tool)
2025-09-09T02:58:59.6575549Z DEBUG: Dependency https://github.com/cert-manager/makefile-modules.git has unsupported/unversioned value main (versioning=semver-coerced) (repository=cert-manager/helm-tool)
2025-09-09T02:58:59.6580036Z DEBUG: Dependency https://github.com/cert-manager/makefile-modules.git has unsupported/unversioned value main (versioning=semver-coerced) (repository=cert-manager/helm-tool)
2025-09-09T02:58:59.6591039Z DEBUG: Dependency https://github.com/cert-manager/makefile-modules.git has unsupported/unversioned value main (versioning=semver-coerced) (repository=cert-manager/helm-tool)
````