### PR TITLE
Remove obsolete JSONata POC

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,36 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>cert-manager/makefile-modules:renovate-config.json5"],
-  "customManagers": [
-    {
-      "customType": "jsonata",
-      "fileFormat": "yaml",
-      "managerFilePatterns": ["klone.yaml"],
-      "matchStrings": [
-        'targets.*.{\
-          "datasource": "git-refs",\
-          "versioning": "git",\
-          "depName": folder_name,\
-          "packageName": repo_url,\
-          "currentValue": repo_ref,\
-          "currentDigest": repo_hash\
-        }',
-      ]
-    }
-  ],
-  packageRules: [
-    {
-      "groupName": 'Makefile Modules',
-      "matchManagers": ["custom.jsonata"],
-      "matchFileNames": ["klone.yaml"],
-      "postUpgradeTasks": {
-        "commands": [
-          "make vendor-go",
-          "make generate-klone",
-          "make generate"
-        ],
-        "executionMode": "branch"
-      }
-    }
-  ]
 }


### PR DESCRIPTION
The POC has now been promoted to makefile-modules, and merged as part of https://github.com/cert-manager/helm-tool/pull/281. So this local configuration is no longer needed.