### PR TITLE
fix: prevent CWD template shadowing and remove non-hermetic sprig functions

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,13 +122,13 @@ func init() {
 	Cmd.PersistentFlags().StringVarP(&valuesFile, "values", "i", "values.yaml", "values file used to generate the documentation")
 
 	Cmd.AddCommand(&Inject)
-	Inject.PersistentFlags().StringVarP(&templateName, "template", "t", "markdown-plain", "template to render documentation with")
+	Inject.PersistentFlags().StringVarP(&templateName, "template", "t", "markdown-plain", "built-in template name or path to a custom template")
 	Inject.PersistentFlags().StringVarP(&targetFile, "output", "o", "README.md", "file to inject the generated markdown into")
 	Inject.PersistentFlags().Var(&headerSearch, "header-search", "set the regex used to match the start of the injected markdown")
 	Inject.PersistentFlags().Var(&footerSearch, "footer-search", "set the regex used to match the end of the injected markdown")
 
 	Cmd.AddCommand(&Render)
-	Render.PersistentFlags().StringVarP(&templateName, "template", "t", "markdown-plain", "template to render documentation with")
+	Render.PersistentFlags().StringVarP(&templateName, "template", "t", "markdown-plain", "built-in template name or path to a custom template")
 
 	Cmd.AddCommand(&Schema)
 

--- a/render/render.go
+++ b/render/render.go
@@ -36,7 +36,21 @@ import (
 //go:embed markdown-table-vertical
 var templates embed.FS
 
+// openTemplate resolves a template name to a readable file.
+//
+// Bare names (without a path separator) are resolved exclusively
+// against the embedded FS, which contains the built-in templates
+// (markdown-plain, markdown-table, markdown-table-vertical). This
+// prevents an attacker-controlled file in the working directory from
+// shadowing a built-in.
+//
+// To use a custom template on the filesystem, pass an explicit path
+// (e.g. -t ./custom.tpl).
 func openTemplate(path string) (fs.File, error) {
+	if !strings.ContainsRune(path, os.PathSeparator) {
+		return templates.Open(path)
+	}
+
 	file, err := os.Open(path)
 	if os.IsNotExist(err) {
 		return templates.Open(path)
@@ -62,7 +76,7 @@ func Render(templateName string, document *parser.Document) (string, error) {
 		return "", err
 	}
 
-	funcMap := sprig.TxtFuncMap()
+	funcMap := sprig.HermeticTxtFuncMap()
 	funcMap["indentWith"] = func(pad string, v string) string {
 		return pad + strings.ReplaceAll(v, "\n", "\n"+pad)
 	}


### PR DESCRIPTION
### Description

render.openTemplate() previously consulted the process CWD via os.Open() before falling back to the embedded FS, allowing an attacker who controls the chart directory (e.g. a PR author) to shadow a built-in template and exfiltrate CI environment secrets via env/expandenv/getHostByName from the non-hermetic sprig.TxtFuncMap().

### Changes (render/render.go):

  - openTemplate: bare names (no path separator) now resolve directly against the embedded FS. Filesystem overrides still work but require an explicit path (e.g. -t ./custom.tpl).
  - Render: switched from sprig.TxtFuncMap() to sprig.HermeticTxtFuncMap(), which removes env, expandenv, and getHostByName (the primary exfil channels) as well as date/now/rand*/uuidv4 and cert-generation functions. All three built-in templates use only eq, replace, and the custom indentWith, so there is no regression on the default path. External users with operator-supplied templates that rely on e.g. date will need to inline that logic.

### Manual testing:

  With a malicious ./markdown-plain file (containing {{ env "HOME" }}) present in the chart root alongside values.yaml:
  - helm-tool render used the embedded template and produced correct output — no env values leaked
  - helm-tool inject likewise wrote clean embedded-template output into README.md
  - All three built-in template names (markdown-plain, markdown-table, markdown-table-vertical) were verified protected against shadowing
  - helm-tool render -t ./custom.tpl confirmed explicit-path overrides still work
  - helm-tool render -t ./evil.tpl (explicit path, contains {{ env "HOME" }}) returned function "env" not defined and exited with an error — no data leaked even via the operator-supplied path