### PR TITLE
linter: bound template reference graph traversal

### DIFF
--- a/linter/parsetemplates/templates.go
+++ b/linter/parsetemplates/templates.go
@@ -90,6 +90,12 @@ type templateUsage struct {
 const (
 	RootNode = "<root-node>"
 	RootPath = "<root-path>"
+
+	// maxFollowPathVisits caps followPath's total node visits. It enumerates
+	// every acyclic path, so an attacker-supplied width-2 lattice of depth k has
+	// 2^k paths and can exhaust CPU/memory (CWE-407). This bound is far above any
+	// real chart; exceeding it is an error, not a silent truncation.
+	maxFollowPathVisits = 1_000_000
 )
 
 func ListTemplatePathsFromTemplates(
@@ -137,7 +143,8 @@ func ListTemplatePathsFromTemplates(
 		)
 	}
 
-	followPath(RootNode, sets.Set[string]{}, templateUsages, func(node, path string) {
+	budget := maxFollowPathVisits
+	completed := followPath(RootNode, sets.Set[string]{}, &budget, templateUsages, func(node, path string) {
 		for key := range templateResults[node] {
 			if strings.HasPrefix(key, RootPath) {
 				templateResults[RootNode].Insert(key)
@@ -146,6 +153,14 @@ func ListTemplatePathsFromTemplates(
 			}
 		}
 	})
+	if !completed {
+		return nil, fmt.Errorf(
+			"template reference graph is too complex to analyse (exceeded %d node visits): "+
+				"this usually means the templates contain an excessively deep or highly branching "+
+				"set of {{ template }}/{{ include }} references",
+			maxFollowPathVisits,
+		)
+	}
 
 	paths := sets.Set[string]{}
 	for key := range templateResults[RootNode] {
@@ -158,26 +173,42 @@ func ListTemplatePathsFromTemplates(
 	return sets.RemovePrefixes(paths), nil
 }
 
+// followPath walks the template reference graph from node, invoking run for
+// every reachable node. budget is shared across the recursion and decremented
+// per visit; it returns false (incomplete, results must be discarded) if the
+// walk was aborted on budget exhaustion, true otherwise.
 func followPath(
 	node string,
 	visited sets.Set[string],
+	budget *int,
 	templateUsage map[string]sets.Set[templateUsage],
 	run func(node string, path string),
-) {
+) bool {
+	if *budget <= 0 {
+		return false
+	}
+	*budget--
+
 	if visited.Has(node) {
-		return
+		return true
 	}
 	visited.Insert(node)
 
+	completed := true
 	for usage := range templateUsage[node] {
 		// Recursively follow the path until we reach the <root-node>
-		followPath(usage.node, visited, templateUsage, func(node, path string) {
+		if !followPath(usage.node, visited, budget, templateUsage, func(node, path string) {
 			run(node, joinPath(usage.context, path))
-		})
+		}) {
+			completed = false
+			break
+		}
 	}
 	run(node, "")
 
 	visited.Delete(node)
+
+	return completed
 }
 
 func walk(

--- a/linter/parsetemplates/templates_test.go
+++ b/linter/parsetemplates/templates_test.go
@@ -19,6 +19,7 @@ package parsetemplates_test
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -285,4 +286,32 @@ func TestListTemplatePathsFromTemplates(t *testing.T) {
 
 		require.EqualValues(t, tc.expectedPaths, pathList)
 	}
+}
+
+// TestListTemplatePathsExponentialLattice guards against CWE-407: a width-2
+// lattice of depth k has 2^k acyclic paths, so the walk must abort with an
+// error rather than enumerate them all. depth=30 => 2^30 paths, well past the
+// visit budget.
+func TestListTemplatePathsExponentialLattice(t *testing.T) {
+	const depth = 30
+
+	var b strings.Builder
+	for i := range depth {
+		// Two calls with different contexts (.a/.b) => two distinct edges.
+		fmt.Fprintf(&b, "{{define \"n%d\"}}{{template \"n%d\" .a}}{{template \"n%d\" .b}}{{end}}", i, i+1, i+1)
+	}
+	fmt.Fprintf(&b, "{{define \"n%d\"}}{{ .Values.x }}{{end}}", depth)
+	b.WriteString("{{template \"n0\" . }}")
+
+	tmpl := template.New("ROOT")
+	tmpl.Funcs(funcs_serdes.FuncMap())
+
+	templates := sets.Set[*template.Template]{}
+	tpl, err := tmpl.New("boom").Parse(b.String())
+	require.NoError(t, err)
+	templates[tpl] = struct{}{}
+
+	_, err = parsetemplates.ListTemplatePathsFromTemplates(tmpl, templates)
+	require.Error(t, err, "expected the exponential lattice to be rejected, not enumerated")
+	require.Contains(t, err.Error(), "too complex")
 }


### PR DESCRIPTION
## Description

### Problem
`helm-tool lint` builds a graph of which templates reference which, then walks it with `followPath` to collect every value path a template might use. The `visited` set is deleted on unwind, so it only guards against cycles — it provides no memoization. A node reachable by N distinct routes is re-walked N times.

An attacker who can supply templates (a PR author or an upstream chart publisher) can define a width-2 lattice — each template calling the next one twice with different contexts — so that depth `k` yields `2^k` traversals. A ~2 KB file at depth 40 forces >10¹² traversals, pegging a CPU core and allocating memory until the lint process is OOM-killed or hits the CI timeout. No data is disclosed or modified; the impact is denial of service.

### Solution
Thread a shared visit budget through `followPath` and decrement it once per node visit. When the budget is exhausted the walk aborts and `ListTemplatePathsFromTemplates` returns a clear error, rather than running unbounded. The cap (1,000,000 visits) is orders of magnitude above what any realistic chart needs, so legitimate charts behave unchanged; the `visited.Delete` cycle-guard semantics are preserved so multi-path helpers still resolve correctly.

## Test plan
- [x] End-to-end: the original [example malicious file](https://github.com/user-attachments/files/29555902/REPRO_lint_dos.md) now exits with an error in ~4.5s instead of running unbounded.
- [x] End-to-end: a normal chart with a multi-path helper still lints correctly.
- [x] `TestListTemplatePathsExponentialLattice` — a width-2 depth-30 lattice returns an error instead of hanging.
- [x] `TestListTemplatePathsFromTemplates` — existing cases (incl. a helper reached via three distinct paths) pass unchanged.
- [x] `go build ./...` and `go vet ./...` clean.
- [x] Full `go test ./...` passes.