### PR TITLE
Honour +docs:section tags regardless of surrounding blank lines

### DIFF
--- a/parser/document.go
+++ b/parser/document.go
@@ -116,7 +116,6 @@ func Load(filename string, includeHidden bool) (*Document, error) {
 		comment := pop(&node.HeadComments)
 
 		parseCommentsOntoDocument(node.Path.Parent(), &document, node.HeadComments)
-		defer parseCommentsOntoDocument(node.Path.Parent(), &document, node.FootComment)
 
 		// If we have a comment instructing us to skip this node, obey it
 		if comment.Tags.GetBool(TagIgnore) {
@@ -142,6 +141,15 @@ func Load(filename string, includeHidden bool) (*Document, error) {
 			return false, nil
 		}
 
+		// With no blank line between them, a +docs:section tag and the
+		// property's description arrive as one comment block. Start the
+		// section here so the tag is not lost with the description.
+		if comment.Tags.GetBool(TagSection) {
+			document.Sections = append(document.Sections, Section{
+				Name: comment.Tags.GetString(TagSection),
+			})
+		}
+
 		sectionIdx := len(document.Sections) - 1
 		document.Sections[sectionIdx].Properties = append(document.Sections[sectionIdx].Properties, Property{
 			Path:        node.Path,
@@ -151,6 +159,10 @@ func Load(filename string, includeHidden bool) (*Document, error) {
 		})
 
 		return true, nil
+	}, func(node Node) {
+		// Foot comments come after the node's children in the file, so they
+		// must be applied after the children have been walked.
+		parseCommentsOntoDocument(node.Path.Parent(), &document, node.FootComment)
 	})
 
 	return &document, err
@@ -243,9 +255,12 @@ func parseCommentsOntoDocument(path paths.Path, document *Document, comments []C
 	}
 }
 
-func walk(root Node, fn func(node Node) (bool, error)) error {
-	// Call the function for every node, we the method can decide to stop
-	// walking this branch as part of this call
+// walk calls fn for every node before its children, and after for every node
+// once its children have been walked. fn can stop the walk of a branch by
+// returning true.
+func walk(root Node, fn func(node Node) (bool, error), after func(node Node)) error {
+	defer after(root)
+
 	stop, err := fn(root)
 	if err != nil {
 		return err
@@ -266,7 +281,7 @@ func walk(root Node, fn func(node Node) (bool, error)) error {
 				RawNode:      node,
 			}
 
-			if err := walk(n, fn); err != nil {
+			if err := walk(n, fn, after); err != nil {
 				return err
 			}
 		}
@@ -282,7 +297,7 @@ func walk(root Node, fn func(node Node) (bool, error)) error {
 				RawNode:      valueNode,
 			}
 
-			if err := walk(n, fn); err != nil {
+			if err := walk(n, fn, after); err != nil {
 				return err
 			}
 		}
@@ -295,7 +310,7 @@ func walk(root Node, fn func(node Node) (bool, error)) error {
 				FootComment:  parseComments(node.FootComment),
 			}
 
-			if err := walk(n, fn); err != nil {
+			if err := walk(n, fn, after); err != nil {
 				return err
 			}
 		}
@@ -307,7 +322,7 @@ func walk(root Node, fn func(node Node) (bool, error)) error {
 			RawNode:      root.RawNode.Alias,
 		}
 
-		if err := walk(n, fn); err != nil {
+		if err := walk(n, fn, after); err != nil {
 			return err
 		}
 	}

--- a/parser/document_test.go
+++ b/parser/document_test.go
@@ -127,3 +127,34 @@ func TestLoad_MissingFile(t *testing.T) {
 	_, err := Load(filepath.Join(t.TempDir(), "does-not-exist.yaml"), false)
 	require.Error(t, err)
 }
+
+// Blank lines around a +docs:section tag must not change which properties
+// belong to the section. See https://github.com/cert-manager/helm-tool/issues/341.
+func TestLoad_SectionTagIgnoresSurroundingBlankLines(t *testing.T) {
+	const before = "# +docs:section=CRDs\ncrds:\n  # Install the CRDs.\n  enabled: true\n"
+	const after = "# The number of replicas.\nreplicaCount: 1\n"
+	want := []string{"CRDs", "crds.enabled", "Main", "replicaCount"}
+
+	for name, tag := range map[string]string{
+		"blank before and after": "\n# +docs:section=Main\n\n",
+		"blank after only":       "# +docs:section=Main\n\n",
+		"blank before only":      "\n# +docs:section=Main\n",
+		"no blank lines":         "# +docs:section=Main\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			doc, err := Load(writeTemp(t, before+tag+after), false)
+			require.NoError(t, err)
+
+			var got []string
+			for _, s := range doc.Sections {
+				if s.Name != "" {
+					got = append(got, s.Name)
+				}
+				for _, p := range s.Properties {
+					got = append(got, p.Path.String())
+				}
+			}
+			assert.Equal(t, want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #341.

A `+docs:section=` tag was silently dropped, or applied to the wrong properties, depending only on the blank lines around it. Both failures are in `parser/document.go`.

**No blank line after the tag.** go-yaml delivers the tag and the property description as one comment block. `Load` used that block as the description and never passed it on, so the section was lost. `Load` now starts the section before adding the property.

**No blank line before the tag.** go-yaml attaches the tag as the foot comment of the preceding mapping key. `Load` applied foot comments in a `defer` that ran before the mapping's children were walked, so the new section was registered first and swallowed them. `walk` now takes an `after` callback that runs once the children have been walked.

The new test covers all four blank-line combinations. It fails on the three broken ones without the fix.

<details>
<summary>Rendered output for the example chart is unchanged</summary>

```
go run . render -t markdown-table-vertical -i examples/cert-manager/values.yaml
```

Byte-identical before and after this change.

</details>

[Claude Fable 5.1]
