### PR TITLE
Add help descriptions to the root, schema and lint commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,7 +40,11 @@ var (
 )
 
 var Cmd = cobra.Command{
-	Use: "helm-tool",
+	Use:   "helm-tool",
+	Short: "generate documentation and a JSON schema for a Helm values file, and lint it",
+	Long: `helm-tool reads a Helm values.yaml file and the comments around each
+property. It uses them to render documentation, generate values.schema.json,
+and lint the values against the chart templates.`,
 }
 
 var Render = cobra.Command{
@@ -81,7 +85,8 @@ var Inject = cobra.Command{
 }
 
 var Schema = cobra.Command{
-	Use: "schema",
+	Use:   "schema",
+	Short: "generate a values.schema.json for the values file and print it to stdout",
 	Run: func(cmd *cobra.Command, args []string) {
 		document, err := parser.Load(valuesFile, true)
 		if err != nil {
@@ -100,7 +105,8 @@ var Schema = cobra.Command{
 }
 
 var Lint = cobra.Command{
-	Use: "lint",
+	Use:   "lint",
+	Short: "check that every property in the values file is used by a template, and vice versa",
 	Run: func(cmd *cobra.Command, args []string) {
 		document, err := parser.Load(valuesFile, true)
 		if err != nil {


### PR DESCRIPTION
Fixes #263.

`helm-tool --help` listed `lint` and `schema` with no description, and the per-command help for those two did not say what they do. This adds a `Short` description to both, and a `Short` and `Long` to the root command.

<details>
<summary>New output of <code>helm-tool --help</code></summary>

```
helm-tool reads a Helm values.yaml file and the comments around each
property. It uses them to render documentation, generate values.schema.json,
and lint the values against the chart templates.

Usage:
  helm-tool [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  inject      generate documentation and inject into existing markdown file
  lint        check that every property in the values file is used by a template, and vice versa
  render      render documentation to stdout
  schema      generate a values.schema.json for the values file and print it to stdout
```

</details>

[Claude Fable 5.1]
