### PR TITLE
Keep "WARNING:" labels on their own line and join lines that open with a bracket

### DIFF
--- a/heuristics/newlines.go
+++ b/heuristics/newlines.go
@@ -24,6 +24,10 @@ import (
 
 var numericListExp = regexp.MustCompile(`^[0-9]+\s*[-\.]$`)
 
+// labelExp matches lines starting with an upper case label such as
+// "WARNING:" or "NOTE:", which authors put on their own line.
+var labelExp = regexp.MustCompile(`^[A-Z]{2,}:`)
+
 // RecutNewLines attempts to recut new lines that may have been wrapped to
 // remove the wrapping, while trying to preserve intentional new lines for
 // lists, code etc.
@@ -77,13 +81,25 @@ func RecutNewLines(lines []string) []string {
 		}
 
 		// If we start with a non alphanumeric character then assume the
-		// new line was intended (it could be a list for example)
-		if c := firstChar(trimmedLine); !unicode.IsLetter(c) && !unicode.IsNumber(c) {
+		// new line was intended (it could be a list for example). Opening
+		// brackets and quotes are the exception: "(Certificates, ...)" or
+		// "[link](url)" continue the wrapped sentence above.
+		if c := firstChar(trimmedLine); !unicode.IsLetter(c) && !unicode.IsNumber(c) && !strings.ContainsRune(`(["'`, c) {
 			if len(currentLine) != 0 {
 				parsedLines = append(parsedLines, strings.Join(currentLine, " "))
 			}
 			parsedLines = append(parsedLines, lineWithoutLeadingSpaces)
 			currentLine = nil
+			continue
+		}
+
+		// If we start with a label such as "WARNING:", the new line is
+		// intended, but the lines that follow may still be wrapped onto it
+		if labelExp.MatchString(trimmedLine) {
+			if len(currentLine) != 0 {
+				parsedLines = append(parsedLines, strings.Join(currentLine, " "))
+			}
+			currentLine = []string{lineWithoutLeadingSpaces}
 			continue
 		}
 

--- a/heuristics/newlines_test.go
+++ b/heuristics/newlines_test.go
@@ -59,6 +59,26 @@ func TestRecutNewLines(t *testing.T) {
 				},
 			},
 		},
+		{
+			"LabelAndBracketContinuation",
+			args{
+				[]string{
+					" This option makes it so that the \"helm.sh/resource-policy\": keep",
+					" annotation is added to the CRD. This will prevent Helm from uninstalling",
+					" the CRD when the Helm release is uninstalled.",
+					" WARNING: when the CRDs are removed, all cert-manager custom resources",
+					" (Certificates, Issuers, ...) will be removed too by the garbage collector.",
+					" The value must be between 1 and 30 seconds. For more information, see",
+					" [Kubernetes GitHub repository](https://kubernetes.io/).",
+				},
+			},
+			want{
+				[]string{
+					"This option makes it so that the \"helm.sh/resource-policy\": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled.",
+					"WARNING: when the CRDs are removed, all cert-manager custom resources (Certificates, Issuers, ...) will be removed too by the garbage collector. The value must be between 1 and 30 seconds. For more information, see [Kubernetes GitHub repository](https://kubernetes.io/).",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #26

`helm-tool inject` put markdown line breaks in the wrong places in wrapped comments. A `WARNING:` line longer than 50 characters was joined onto the sentence above it. The next line, starting with `(`, was then forced onto its own line. The result was a line break half way through the warning.

Two heuristic changes fix this:

- A line starting with an upper case label such as `WARNING:` or `NOTE:` starts a new line. Wrapped lines after it join onto it.
- A line starting with an opening bracket or quote continues the sentence above. Real charts use this for `(pods, services, ...)` and `[link text](url)` at the start of a line.

<details>
<summary>Effect on the cert-manager, approver-policy and trust-manager charts</summary>

Only these paragraphs change. Before on the left, after on the right.

```diff
-This option makes it so that the "helm.sh/resource-policy": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager custom resources  
-(Certificates, Issuers, ...) will be removed too by the garbage collector.
+This option makes it so that the "helm.sh/resource-policy": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled.  
+WARNING: when the CRDs are removed, all cert-manager custom resources (Certificates, Issuers, ...) will be removed too by the garbage collector.

-Override the "cert-manager.name" value, which is used to annotate some of the resources that are created by this Chart (using "app.kubernetes.io/name"). NOTE: There are some inconsistencies in the Helm chart when it comes to these annotations (some resources use, e.g., "cainjector.name" which resolves to the value "cainjector").
+Override the "cert-manager.name" value, which is used to annotate some of the resources that are created by this Chart (using "app.kubernetes.io/name").  
+NOTE: There are some inconsistencies in the Helm chart when it comes to these annotations (some resources use, e.g., "cainjector.name" which resolves to the value "cainjector").

-These labels are also applied to dynamically-created ACME HTTP01 solver resources  
-(pods, services, ingresses, or Gateway API HTTPRoutes).  
-The following ACME identity label keys are reserved ...
+These labels are also applied to dynamically-created ACME HTTP01 solver resources (pods, services, ingresses, or Gateway API HTTPRoutes). The following ACME identity label keys are reserved ...

-... controller-manager. For more information see the following on the  
-[Kubernetes GitHub repository](https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245).
+... controller-manager. For more information see the following on the [Kubernetes GitHub repository](https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245).

-List of Kubernetes TopologySpreadConstraints. For more information, see:  
-[Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).  
+List of Kubernetes TopologySpreadConstraints. For more information, see: [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).  
```

</details>

The two trailing spaces before a line break are deliberate. Markdown needs them to render a line break, so this PR does not remove them.

[Claude Fable 5.1]
