### PR TITLE
Nest commented-out properties at the end of the file under their parent

### DIFF
--- a/parser/document.go
+++ b/parser/document.go
@@ -93,15 +93,23 @@ type Node struct {
 }
 
 func Load(filename string, includeHidden bool) (*Document, error) {
-	file, err := os.Open(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
+	// Comments at the end of the file are attached to the document node by
+	// the YAML decoder, which loses the mapping they were indented under. A
+	// trailing top-level key makes the decoder attach them to the key they
+	// follow instead. Add one, decode, then remove it again.
+	// See https://github.com/cert-manager/helm-tool/issues/25
+	data = append(data, "\n"+sentinelKey+": null\n"...)
+
 	var root yaml.Node
-	if err := yaml.NewDecoder(file).Decode(&root); err != nil {
+	if err := yaml.Unmarshal(data, &root); err != nil {
 		return nil, err
 	}
+	removeSentinel(&root)
 
 	document := Document{Sections: make([]Section, 1)}
 	node := Node{
@@ -154,6 +162,24 @@ func Load(filename string, includeHidden bool) (*Document, error) {
 	})
 
 	return &document, err
+}
+
+const sentinelKey = "__helm_tool_end_of_file__"
+
+// removeSentinel drops the sentinel key appended by Load from the root
+// mapping. Comments that precede it at column 0 are moved to the document
+// foot comment so they keep being treated as top-level comments.
+func removeSentinel(root *yaml.Node) {
+	if len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+		return
+	}
+	mapping := root.Content[0]
+	n := len(mapping.Content)
+	if n < 2 || mapping.Content[n-2].Value != sentinelKey {
+		return
+	}
+	root.FootComment = mapping.Content[n-2].HeadComment
+	mapping.Content = mapping.Content[:n-2]
 }
 
 func parseCommentsOntoDocument(path paths.Path, document *Document, comments []Comment) {

--- a/parser/document_test.go
+++ b/parser/document_test.go
@@ -127,3 +127,52 @@ func TestLoad_MissingFile(t *testing.T) {
 	_, err := Load(filepath.Join(t.TempDir(), "does-not-exist.yaml"), false)
 	require.Error(t, err)
 }
+
+func propertyPaths(doc *Document) []string {
+	var paths []string
+	for _, s := range doc.Sections {
+		for _, p := range s.Properties {
+			paths = append(paths, p.Path.String())
+		}
+	}
+	return paths
+}
+
+// Commented-out properties at the end of the file must be nested under the
+// mapping they are indented in, not treated as top-level.
+// See https://github.com/cert-manager/helm-tool/issues/25
+func TestLoad_TrailingCommentedPropertiesAreNested(t *testing.T) {
+	yaml := `
+podDisruptionBudget:
+  enabled: false
+
+  # +docs:property
+  # minAvailable: 1
+
+  # +docs:property
+  # maxUnavailable: 1
+`
+	path := writeTemp(t, yaml)
+	doc, err := Load(path, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"podDisruptionBudget.enabled",
+		"podDisruptionBudget.minAvailable",
+		"podDisruptionBudget.maxUnavailable",
+	}, propertyPaths(doc))
+}
+
+// Column-0 comments at the end of the file stay top-level.
+func TestLoad_TrailingTopLevelCommentedProperty(t *testing.T) {
+	yaml := `
+podDisruptionBudget:
+  enabled: false
+
+# +docs:property
+# globalThing: 1
+`
+	path := writeTemp(t, yaml)
+	doc, err := Load(path, false)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"podDisruptionBudget.enabled", "globalThing"}, propertyPaths(doc))
+}


### PR DESCRIPTION
Commented-out `+docs:property` blocks at the end of `values.yaml` are now documented under the mapping they are indented in. Before this change they were documented as top-level properties.

Fixes #25

## Why did this happen?

The YAML decoder attaches comments at the end of the file to the document node, not to the last key. That loses the indentation, so helm-tool had no parent path to prefix. Adding any trailing top-level key made the decoder attach the comments to the key they follow instead, which is the workaround described in the issue.

## What does this change do?

`Load` now appends a top-level sentinel key to the file contents before decoding and removes it from the decoded tree afterwards. Column-0 comments before the sentinel move to the document foot comment, so they stay top-level as before.

<details>
<summary>Evidence</summary>

The `yaml.v3` decoder places end-of-file comments on the document node. Dumping the tree for the values file in the issue, before this change:

```
DocumentNode foot="# Configures the minimum available pods...\n# +docs:property\n# minAvailable: 1\n..."
  MappingNode
    podDisruptionBudget
      MappingNode
        enabled head="# Enable or disable the PodDisruptionBudget resource."
```

With a trailing top-level key appended:

```
DocumentNode
  MappingNode
    podDisruptionBudget
      MappingNode
        enabled foot="# Configures the minimum available pods...\n# +docs:property\n# minAvailable: 1\n..."
    zzz
```

I compared `render` and `schema` output before and after for the cert-manager, approver-policy and trust-manager charts. All are identical.

</details>

[Claude Fable 5.1]
